### PR TITLE
refactor: move extract_file to common directory for reuse

### DIFF
--- a/shuriken/include/shuriken/common/extract_file.h
+++ b/shuriken/include/shuriken/common/extract_file.h
@@ -1,0 +1,21 @@
+//--------------------------------------------------------------------*- C++ -*-
+// Shuriken-Analyzer: library for bytecode analysis.
+// @author Farenain <kunai.static.analysis@gmail.com>
+//
+// @file extract_file.h
+// @brief Utility to extract zip files such as APKs and IPAs
+// types
+
+#ifndef SHURIKENLIB_EXTRACT_FILE_H
+#define SHURIKENLIB_EXTRACT_FILE_H
+
+#include "zip.h"
+#include <string>
+#include <vector>
+#include <fstream>
+#include <iostream>
+
+/// Function to extract a file from a zip archive
+bool extract_file(zip_t *archive, const char *filename, const std::string &output_path);
+
+#endif // SHURIKENLIB_EXTRACT_FILE_H

--- a/shuriken/lib/common/CMakeLists.txt
+++ b/shuriken/lib/common/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(shuriken-obj PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/shurikenstream.cpp
     ${CMAKE_CURRENT_LIST_DIR}/logger.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/extract_file.cpp
 )

--- a/shuriken/lib/common/extract_file.cpp
+++ b/shuriken/lib/common/extract_file.cpp
@@ -1,0 +1,43 @@
+//--------------------------------------------------------------------*- C++ -*-
+// Shuriken-Analyzer: library for bytecode analysis.
+// @author Farenain <kunai.static.analysis@gmail.com>
+//
+// @file extract_file.cpp
+
+#include "shuriken/common/extract_file.h"
+
+bool extract_file(zip_t *archive, const char *filename, const std::string &output_path) {
+    // Open the file inside the archive
+    zip_file_t *file = zip_fopen(archive, filename, 0);
+    if (!file) {
+        std::cerr << "Failed to open " << filename << " in the archive." << std::endl;
+        return false;
+    }
+
+    // Get the file info (like size)
+    struct zip_stat file_stat;
+    zip_stat_init(&file_stat);
+    if (zip_stat(archive, filename, 0, &file_stat) == -1) {
+        std::cerr << "Failed to get file stats for " << filename << std::endl;
+        zip_fclose(file);
+        return false;
+    }
+
+    // Allocate buffer for file content
+    std::vector<char> buffer(file_stat.size);
+
+    // Read the file content
+    zip_fread(file, buffer.data(), buffer.size());
+    zip_fclose(file);
+
+    // Write the file to the output path
+    std::ofstream output_file(output_path, std::ios::binary);
+    if (!output_file) {
+        std::cerr << "Failed to create output file " << output_path << std::endl;
+        return false;
+    }
+    output_file.write(buffer.data(), buffer.size());
+    output_file.close();
+
+    return true;
+}

--- a/shuriken/lib/parser/Apk/apk.cpp
+++ b/shuriken/lib/parser/Apk/apk.cpp
@@ -6,6 +6,7 @@
 
 #include "shuriken/parser/Apk/apk.h"
 #include "shuriken/common/logger.h"
+#include "shuriken/common/extract_file.h"
 #include "shuriken/parser/shuriken_parsers.h"
 
 #include "zip.h"
@@ -13,45 +14,6 @@
 #include <sstream>
 
 using namespace shuriken::parser::apk;
-
-namespace {
-    // Function to extract a file from a zip archive
-    bool extract_file(zip_t *archive, const char *filename, const std::string &output_path) {
-        // Open the file inside the archive
-        zip_file_t *file = zip_fopen(archive, filename, 0);
-        if (!file) {
-            std::cerr << "Failed to open " << filename << " in the archive." << std::endl;
-            return false;
-        }
-
-        // Get the file info (like size)
-        struct zip_stat file_stat;
-        zip_stat_init(&file_stat);
-        if (zip_stat(archive, filename, 0, &file_stat) == -1) {
-            std::cerr << "Failed to get file stats for " << filename << std::endl;
-            zip_fclose(file);
-            return false;
-        }
-
-        // Allocate buffer for file content
-        std::vector<char> buffer(file_stat.size);
-
-        // Read the file content
-        zip_fread(file, buffer.data(), buffer.size());
-        zip_fclose(file);
-
-        // Write the file to the output path
-        std::ofstream output_file(output_path, std::ios::binary);
-        if (!output_file) {
-            std::cerr << "Failed to create output file " << output_path << std::endl;
-            return false;
-        }
-        output_file.write(buffer.data(), buffer.size());
-        output_file.close();
-
-        return true;
-    }
-}// namespace
 
 // Private API
 class Apk::ApkExtractor {


### PR DESCRIPTION
- Extracted the `extract_file` function from apk.cpp
- Created separated header (extract_file.h) and source (extract_file.cpp) files in common directories
- Updated CMakeLists.txt files include the new files in the build

This change centralizes file extraction functionality for better reusability in the future implementation of IPA files.