### PR TITLE
Enable write perm for doxygen ci

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -6,9 +6,12 @@ on:
   push:
     branches:
       - main  # Replace with your default branch
+      - doxygen_issue
 
 jobs:
   generate-docs:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Enabling write perm for CI, github bot failing since it doesn't have write permission to the repo (for documentation purposes)