### PR TITLE
feature/support-for-unicode-strings

### DIFF
--- a/shuriken-dump/shuriken-dump.cpp
+++ b/shuriken-dump/shuriken-dump.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
             {"-f", [&]() { fields = true; }},
             {"-b", [&]() { code = true; }},
             {"-D", [&]() { disassembly = true; }},
-            {"-u", [&]() { unicode  = true; }},
+            {"-u", [&]() { unicode = true; }},
             {"-B", [&]() { blocks = true; }},
             {"-x", [&]() { xrefs = true; }},
             {"-T", [&]() { running_time = true; }},
@@ -346,16 +346,20 @@ void print_method(shuriken::parser::dex::EncodedMethod *method, size_t j) {
             throw std::runtime_error("The method " + std::string(method_id->demangle()) + " was not correctly disassembled");
         if (unicode) {
             std::wcout << disassembled_method->print_method_unicode() << L'\n';
-        }
-        else
+        } else {
             fmt::print("{}\n", disassembled_method->print_method());
+        }
     }
     if (blocks) {
         auto method_analysis = analysis->get_method(method);
         if (method_analysis == nullptr) return;
 
         if (method_analysis) {
-            fmt::print("\n{}\n", method_analysis->toString());
+            if (unicode) {
+                std::wcout << method_analysis->toWString() << L'\n';
+            } else {
+                fmt::print("\n{}\n", method_analysis->toString());
+            }
         }
     }
     if (xrefs) {

--- a/shuriken-dump/shuriken-dump.cpp
+++ b/shuriken-dump/shuriken-dump.cpp
@@ -29,8 +29,8 @@ void show_help(std::string &prog_name) {
     fmt::println(" -N: analyze but do not print any information");
 }
 
-void parse_dex(std::string& dex_file);
-void parse_apk(std::string& apk_file);
+void parse_dex(std::string &dex_file);
+void parse_apk(std::string &apk_file);
 void print_header(shuriken::parser::dex::DexHeader &);
 void print_classes(shuriken::parser::dex::DexClasses &);
 void print_method(shuriken::parser::dex::EncodedMethod *, size_t);
@@ -51,9 +51,9 @@ bool no_print = false;
 std::unique_ptr<shuriken::parser::apk::Apk> parsed_apk = nullptr;
 std::unique_ptr<shuriken::parser::dex::Parser> parsed_dex = nullptr;
 std::unique_ptr<shuriken::disassembler::dex::DexDisassembler> disassembler_own = nullptr;
-shuriken::disassembler::dex::DexDisassembler * disassembler = nullptr;
+shuriken::disassembler::dex::DexDisassembler *disassembler = nullptr;
 std::unique_ptr<shuriken::analysis::dex::Analysis> dex_analysis_own = nullptr;
-shuriken::analysis::dex::Analysis * analysis = nullptr;
+shuriken::analysis::dex::Analysis *analysis = nullptr;
 
 int main(int argc, char **argv) {
     std::vector<std::string> args{argv, argv + argc};
@@ -75,8 +75,7 @@ int main(int argc, char **argv) {
             {"-B", [&]() { blocks = true; }},
             {"-x", [&]() { xrefs = true; }},
             {"-T", [&]() { running_time = true; }},
-            {"-N", [&]() { no_print = true; }}
-    };
+            {"-N", [&]() { no_print = true; }}};
 
     for (const auto &s: args) {
         if (auto it = options.find(s); it != options.end()) {
@@ -85,7 +84,7 @@ int main(int argc, char **argv) {
     }
 
     try {
-        if (args[1].ends_with(".dex")) { // manage dex file :)
+        if (args[1].ends_with(".dex")) {// manage dex file :)
             parse_dex(args[1]);
         } else if (args[1].ends_with(".apk")) {
             parse_apk(args[1]);
@@ -117,7 +116,7 @@ int main(int argc, char **argv) {
     return 0;
 }
 
-void parse_dex(std::string& dex_file) {
+void parse_dex(std::string &dex_file) {
     parsed_dex = shuriken::parser::parse_dex(dex_file);
 
     if (disassembly) {
@@ -148,27 +147,26 @@ void parse_dex(std::string& dex_file) {
     }
 }
 
-void parse_apk(std::string& apk_file) {
+void parse_apk(std::string &apk_file) {
     parsed_apk = shuriken::parser::parse_apk(apk_file, xrefs ? true : false);
 
     disassembler = parsed_apk->get_global_disassembler();
     analysis = parsed_apk->get_global_analysis();
 
-    for (auto & file_name : parsed_apk->get_dex_files_names()) {
+    for (auto &file_name: parsed_apk->get_dex_files_names()) {
         fmt::println("DEX File: {}", file_name);
     }
 
     if (!no_print) {
-        for (auto & file_parser : parsed_apk->get_dex_parsers()) {
-            auto & parsed_dex = file_parser.second.get();
-            auto & header = parsed_dex.get_header();
+        for (auto &file_parser: parsed_apk->get_dex_parsers()) {
+            auto &parsed_dex = file_parser.second.get();
+            auto &header = parsed_dex.get_header();
 
             fmt::println("Analysis of file: {}", file_parser.first);
             if (headers) print_header(header);
             if (show_classes) print_classes(parsed_dex.get_classes());
         }
     }
-
 }
 
 void print_header(shuriken::parser::dex::DexHeader &header) {
@@ -274,16 +272,15 @@ void print_classes(shuriken::parser::dex::DexClasses &classes) {
 
             auto xrefconstclass = class_analysis->get_xrefconstclass();
             fmt::print("  XREF Const Class:\n");
-            for (auto & xref : xrefconstclass) {
+            for (auto &xref: xrefconstclass) {
                 fmt::print("   - {}:{}\n", xref.first->get_full_name(), xref.second);
             }
             auto xrefnewinstance = class_analysis->get_xrefnewinstance();
             fmt::print("  XREF New Instance:\n");
-            for (auto & xref : xrefnewinstance) {
+            for (auto &xref: xrefnewinstance) {
                 fmt::print("   - {}:{}\n", xref.first->get_full_name(), xref.second);
             }
         }
-
     }
 }
 
@@ -299,16 +296,16 @@ void print_field(shuriken::parser::dex::EncodedField *field, size_t j) {
         if (field_analysis == nullptr) return;
         auto xref_read = field_analysis->get_xrefread();
         fmt::print("    Xrefs Read:\n");
-        for (auto & xref : xref_read) {
+        for (auto &xref: xref_read) {
             fmt::print("      {}:{}\n",
-                       std::get<shuriken::analysis::dex::MethodAnalysis*>(xref)->get_full_name(),
+                       std::get<shuriken::analysis::dex::MethodAnalysis *>(xref)->get_full_name(),
                        std::get<std::uint64_t>(xref));
         }
         auto xref_write = field_analysis->get_xrefwrite();
         fmt::print("    Xrefs Write:\n");
-        for (auto & xref : xref_write) {
+        for (auto &xref: xref_write) {
             fmt::print("      {}:{}\n",
-                       std::get<shuriken::analysis::dex::MethodAnalysis*>(xref)->get_full_name(),
+                       std::get<shuriken::analysis::dex::MethodAnalysis *>(xref)->get_full_name(),
                        std::get<std::uint64_t>(xref));
         }
     }
@@ -361,19 +358,17 @@ void print_method(shuriken::parser::dex::EncodedMethod *method, size_t j) {
 
         auto xrefto = method_analysis->get_xrefto();
         fmt::print("     XREF To:\n");
-        for (auto & xref : xrefto) {
-                fmt::print("      - {}:{}\n",
-                           std::get<shuriken::analysis::dex::MethodAnalysis*>(xref)->get_full_name(),
-                           std::get<std::uint64_t>(xref));
-
+        for (auto &xref: xrefto) {
+            fmt::print("      - {}:{}\n",
+                       std::get<shuriken::analysis::dex::MethodAnalysis *>(xref)->get_full_name(),
+                       std::get<std::uint64_t>(xref));
         }
         auto xreffrom = method_analysis->get_xreffrom();
         fmt::print("     XREF From:\n");
-        for (auto & xref : xreffrom) {
+        for (auto &xref: xreffrom) {
             fmt::print("      - {}:{}\n",
-                       std::get<shuriken::analysis::dex::MethodAnalysis*>(xref)->get_full_name(),
+                       std::get<shuriken::analysis::dex::MethodAnalysis *>(xref)->get_full_name(),
                        std::get<std::uint64_t>(xref));
-
         }
     }
 }

--- a/shuriken/include/shuriken/analysis/Dex/dex_analysis.h
+++ b/shuriken/include/shuriken/analysis/Dex/dex_analysis.h
@@ -72,6 +72,9 @@ namespace shuriken::analysis::dex {
         /// @brief String that stores a whole block representation
         std::string block_string;
 
+        /// @brief WString that stores a whole block representation
+        std::wstring block_wstring;
+
     public:
         using read_instructions_t = std::span<disassembler::dex::Instruction *>;
         using read_instructions_iterator_t = read_instructions_t::iterator;
@@ -149,8 +152,14 @@ namespace shuriken::analysis::dex {
         /// @brief Set a handler type
         /// @param handler handler type
         void set_handler_type(parser::dex::DVMType *handler);
-
+        
+        /// @brief Retrieve the representation of the block as string
+        /// @return string representation of the block
         std::string_view toString();
+
+        /// @brief Retrieve the representation of the block as wstring
+        /// @return wstring representation of the block
+        std::wstring_view toWString();
     };
 
     /// @brief Class to keep all the Dalvik Basic Blocks from a method
@@ -203,6 +212,8 @@ namespace shuriken::analysis::dex {
         /// @brief All the basic blocks from the method
         std::string basic_blocks_string;
 
+        /// @brief All the basic blocks from the method as wstring
+        std::wstring basic_blocks_wstring;
     public:
         /// @return iterator to all the nodes
         iterator_range<nodesiterator_t> nodes();
@@ -281,7 +292,9 @@ namespace shuriken::analysis::dex {
         /// @return block that contains an instruction in that address
         DVMBasicBlock *get_basic_block_by_idx(std::uint64_t idx);
 
-        std::string toString();
+        std::string_view toString();
+
+        std::wstring_view toWString();
     };
 
     /// @brief specification of a field analysis
@@ -417,6 +430,9 @@ namespace shuriken::analysis::dex {
         /// @brief cache of method string
         std::string method_string;
 
+        /// @brief cache of method wstring
+        std::wstring method_wstring;
+
         /**** Private Methods ****/
         /// @brief Pretty print an instruction and its opcodes in a dot format to an output dot file
         /// @param dot_file file where to dump the instruction
@@ -482,6 +498,8 @@ namespace shuriken::analysis::dex {
         std::string_view get_full_name() const;
 
         std::string_view toString();
+
+        std::wstring_view toWString();
 
         /// @brief Retrieve a pointer to an instruction by a given address
         /// @param addr address of the instruction to retrieve

--- a/shuriken/include/shuriken/common/shurikenstream.h
+++ b/shuriken/include/shuriken/common/shurikenstream.h
@@ -78,6 +78,11 @@ namespace shuriken::common {
         /// @return string read
         std::string read_ansii_string(std::int64_t offset);
 
+        /// @brief Read a wstring as an array of wchar.
+        /// @param offset the offset in the file where to read the string
+        /// @return wstring read
+        std::wstring read_unicode_string(std::int64_t offset);
+
         /// @brief Read a dex string, these DexStrings start always with their size
         /// in uleb128 format.
         /// @param offset the offset in the file where to read the string

--- a/shuriken/include/shuriken/disassembler/Dex/dex_instructions.h
+++ b/shuriken/include/shuriken/disassembler/Dex/dex_instructions.h
@@ -28,7 +28,8 @@ namespace shuriken::disassembler::dex {
             shuriken::parser::dex::FieldID *,
             shuriken::parser::dex::MethodID *,
             shuriken::parser::dex::ProtoID *,
-            std::string_view>;
+            std::string_view,
+            std::wstring_view>;
 
 
     /// Forward declaration of different type of switch
@@ -86,6 +87,8 @@ namespace shuriken::disassembler::dex {
         std::uint64_t address;
         /// @brief string representation of the instruction
         std::string instruction_str;
+        /// @brief wstring representation of the instruction
+        std::wstring instruction_wstr;
 
     public:
         /// @brief Constructor of the Instruction, here is applied
@@ -131,12 +134,16 @@ namespace shuriken::disassembler::dex {
         virtual std::uint64_t get_address() const;
 
         /// @brief Return a string with the representation of the instruction
-        /// @return string with instruction
+        /// @return wstring with instruction
         virtual std::string_view print_instruction() = 0;
 
         /// @brief Print the instruction on a given stream
         /// @param os stream where to print the instruction
         virtual void print_instruction(std::ostream &os) = 0;
+
+        /// @brief Return a wstring with the representation of the instruction
+        /// @return wstring_view with instruction
+        virtual std::wstring_view print_winstruction();
 
         /// @brief Return the op codes in raw from the instruction
         /// @return copy of the span with the raw bytecode
@@ -572,6 +579,8 @@ namespace shuriken::disassembler::dex {
         std::uint16_t iBBBB;
         /// @brief Kind depending on the value
         kind_type_t source_id;
+        /// @brief In case of string, keep a pointer to the unicode version
+        std::wstring_view wstr;
 
     public:
         Instruction21c(std::span<uint8_t> bytecode, std::size_t index);
@@ -612,6 +621,10 @@ namespace shuriken::disassembler::dex {
         /// @brief Print the instruction on a given stream
         /// @param os stream where to print the instruction
         void print_instruction(std::ostream &os) override;
+
+        /// @brief Return a wstring with the representation of the instruction
+        /// @return wstring with instruction
+        std::wstring_view print_winstruction() override;
     };
 
     /// @brief Perform indicated floating point or long comparison

--- a/shuriken/include/shuriken/disassembler/Dex/disassembled_method.h
+++ b/shuriken/include/shuriken/disassembler/Dex/disassembled_method.h
@@ -58,6 +58,8 @@ namespace shuriken::disassembler::dex {
         instructions_raw_t instructions_raw;
         /// @brief representation of the method in string format
         std::string method_string;
+        /// @brief representation of the method in wstring format
+        std::wstring method_wstring;
         /// @brief Access flags from the instruction for the representation
         shuriken::dex::TYPES::access_flags access_flags;
 
@@ -109,6 +111,11 @@ namespace shuriken::disassembler::dex {
         /// @param print_address print the address from each instruction
         /// @return disassembled method string
         std::string_view print_method(bool print_address = true);
+        
+        /// @brief Get a disassembled representation of the method in wstring format
+        /// @param print_address print the address from each instruction
+        /// @return disassembled method wstring
+        std::wstring_view print_method_unicode(bool print_address = true);
     };
 }// namespace shuriken::disassembler::dex
 

--- a/shuriken/include/shuriken/parser/Dex/dex_strings.h
+++ b/shuriken/include/shuriken/parser/Dex/dex_strings.h
@@ -22,12 +22,20 @@ namespace shuriken::parser::dex {
 
     using dex_strings_view_t = std::vector<std::string_view>;
 
+    using dex_wstrings_t = std::vector<std::wstring>;
+
+    using dex_wstrings_view_t = std::vector<std::wstring_view>;
+
     class DexStrings {
     private:
         /// @brief Vector with all the DexStrings from the dex file
         dex_strings_t dex_strings;
         /// @brief View of the previous DexStrings for quickly accessing them
         mutable dex_strings_view_t dex_strings_view;
+        /// @brief Vector with the unicode strings
+        dex_wstrings_t dex_wstrings;
+        /// @brief View of the previous unicode DexStrings
+        mutable dex_wstrings_view_t dex_wstrings_view;
 
     public:
         /// @brief Constructor of the class, default one
@@ -39,14 +47,21 @@ namespace shuriken::parser::dex {
         /// @param shuriken_stream stream with the dex file
         /// @param strings_offset offset in the file where DexStrings are
         /// @param n_of_strings number of DexStrings to read
+        /// @param read_unicode read strings also as unicode
         void parse_strings(common::ShurikenStream &shuriken_stream,
                            std::uint32_t strings_offset,
-                           std::uint32_t n_of_strings);
+                           std::uint32_t n_of_strings,
+                           bool read_unicode);
 
         /// @brief get an string_view by the id of the string (position in the list)
         /// @param str_id id of the string to retrieve
         /// @return a read-only version of the string
         std::string_view get_string_by_id(std::uint32_t str_id) const;
+
+        /// @brief get an wstring_view by the id of the string (position in the list)
+        /// @param str_id id of the wstring to retrieve
+        /// @return a read-only version of the wstring
+        std::wstring_view get_unicode_string_by_id(std::uint32_t str_id) const;
 
         /// @brief get the number of DexStrings from the dex file
         /// @return number of DexStrings

--- a/shuriken/include/shuriken/parser/Dex/dex_strings.h
+++ b/shuriken/include/shuriken/parser/Dex/dex_strings.h
@@ -36,6 +36,8 @@ namespace shuriken::parser::dex {
         dex_wstrings_t dex_wstrings;
         /// @brief View of the previous unicode DexStrings
         mutable dex_wstrings_view_t dex_wstrings_view;
+        /// @brief option to check if unicode is available
+        bool unicode_available;
 
     public:
         /// @brief Constructor of the class, default one
@@ -62,6 +64,10 @@ namespace shuriken::parser::dex {
         /// @param str_id id of the wstring to retrieve
         /// @return a read-only version of the wstring
         std::wstring_view get_unicode_string_by_id(std::uint32_t str_id) const;
+        
+        /// @brief Return if unicode strings are available
+        /// @return unicode strings are available
+        bool is_unicode_available() const;
 
         /// @brief get the number of DexStrings from the dex file
         /// @return number of DexStrings

--- a/shuriken/include/shuriken/parser/Dex/parser.h
+++ b/shuriken/include/shuriken/parser/Dex/parser.h
@@ -27,6 +27,11 @@ namespace shuriken::parser::dex {
 
     class Parser {
     private:
+        // Options for the parser, we can set them before
+        // calling parse_dex and they will be applied
+
+        /// @brief read the unicode strings
+        bool read_unicode;
         /// @brief DexHeader of the DEX file
         DexHeader header_;
         /// @brief Structure with information of the DEX file
@@ -49,6 +54,10 @@ namespace shuriken::parser::dex {
         Parser() = default;
         /// @brief Default destructor of the java
         ~Parser() = default;
+
+        
+
+        void set_read_unicode(bool);
 
         /// @brief parse the dex file from the stream
         /// @param stream stream from where to retrieve the dex data

--- a/shuriken/include/shuriken/parser/shuriken_parsers.h
+++ b/shuriken/include/shuriken/parser/shuriken_parsers.h
@@ -16,9 +16,13 @@
 #include <memory>
 
 namespace shuriken::parser {
-    std::unique_ptr<dex::Parser> parse_dex(common::ShurikenStream &file);
-    std::unique_ptr<dex::Parser> parse_dex(const std::string &file_path);
-    dex::Parser *parse_dex(const char *file_path);
+    std::unique_ptr<dex::Parser> parse_dex(common::ShurikenStream &file,
+                                           bool read_unicode = false);
+    std::unique_ptr<dex::Parser> parse_dex(const std::string &file_path,
+                                           bool read_unicode = false);
+    dex::Parser *parse_dex(const char *file_path,
+                           bool read_unicode = false);
+
 
     std::unique_ptr<apk::Apk> parse_apk(const std::string &file_path, bool created_xrefs);
     std::unique_ptr<apk::Apk> parse_apk(const char *file_path, bool created_xrefs);

--- a/shuriken/lib/analysis/Dex/basic_blocks.cpp
+++ b/shuriken/lib/analysis/Dex/basic_blocks.cpp
@@ -104,8 +104,9 @@ std::string_view DVMBasicBlock::toString() {
             }
 
             ss << '\n';
-        } else if (is_catch_block())
+        } else if (is_catch_block()) {
             ss << ".catch_block" << '\n';
+        }
         for (disassembler::dex::Instruction *insn: instructions_) {
             ss << std::hex << std::setw(8)
                << std::setfill('0')
@@ -115,6 +116,34 @@ std::string_view DVMBasicBlock::toString() {
         block_string = ss.str();
     }
     return block_string;
+}
+
+std::wstring_view DVMBasicBlock::toWString() {
+    if (block_wstring.empty()) {
+        std::wstringstream ss;
+        ss << get_name().data() << '\n';
+        if (is_try_block()) {
+            ss << ".try_block ";
+
+            for (DVMBasicBlock *basicBlock: catch_blocks) {
+                ss << " catch-block "
+                   << basicBlock->get_name().data();
+                if (basicBlock->get_handler_type())
+                    ss << " (" << basicBlock->get_handler_type()->print_type().data() << ")";
+            }
+
+            ss << '\n';
+        } else if (is_catch_block()) {
+            ss << ".catch_block" << '\n';
+        }
+        for (disassembler::dex::Instruction *insn: instructions_) {
+            ss << std::hex << std::setw(8) << std::setfill(L'0');
+            ss << insn->get_address();
+            ss << ' ' << insn->print_winstruction() << '\n';
+        }
+        block_wstring = ss.str();
+    }
+    return block_wstring;
 }
 
 // ---------------------- BasicBlocks ----------------------
@@ -313,7 +342,7 @@ DVMBasicBlock *BasicBlocks::get_basic_block_by_idx(std::uint64_t idx) {
     return *it;
 }
 
-std::string BasicBlocks::toString() {
+std::string_view BasicBlocks::toString() {
     if (basic_blocks_string.empty()) {
         std::stringstream ss;
         for (DVMBasicBlock *dvmBasicBlock: nodes_) {
@@ -331,4 +360,24 @@ std::string BasicBlocks::toString() {
         basic_blocks_string = ss.str();
     }
     return basic_blocks_string;
+}
+
+std::wstring_view BasicBlocks::toWString() {
+    if (basic_blocks_wstring.empty()) {
+        std::wstringstream ss;
+        for (DVMBasicBlock *dvmBasicBlock: nodes_) {
+            ss << dvmBasicBlock->toWString();
+            ss << "Predecessors: ";
+            for (DVMBasicBlock *pred: predecessors_[dvmBasicBlock]) {
+                ss << pred->get_name().data() << " ";
+            }
+            ss << "\nSuccessors: ";
+            for (DVMBasicBlock *succ: successors_[dvmBasicBlock]) {
+                ss << succ->get_name().data() << " ";
+            }
+            ss << "\n\n";
+        }
+        basic_blocks_wstring = ss.str();
+    }
+    return basic_blocks_wstring;
 }

--- a/shuriken/lib/analysis/Dex/method_analysis.cpp
+++ b/shuriken/lib/analysis/Dex/method_analysis.cpp
@@ -89,6 +89,16 @@ std::string_view MethodAnalysis::toString() {
     return method_string;
 }
 
+std::wstring_view MethodAnalysis::toWString() {
+    if (method_wstring.empty()) {
+        std::wstringstream ss;
+        ss << get_full_name().data() << '\n';
+        ss << basic_blocks->toWString();
+        method_wstring = ss.str();
+    }
+    return method_wstring;
+}
+
 shuriken::disassembler::dex::Instruction *MethodAnalysis::get_instruction_by_addr(std::uint64_t addr) {
     for (auto instr: disassembled->get_instructions()) {
         if (instr->get_address() == addr) return instr;

--- a/shuriken/lib/common/shurikenstream.cpp
+++ b/shuriken/lib/common/shurikenstream.cpp
@@ -102,6 +102,30 @@ std::string ShurikenStream::read_ansii_string(std::int64_t offset) {
     return new_str;
 }
 
+std::wstring ShurikenStream::read_unicode_string(std::int64_t offset) {
+    std::wstring new_str = L"";
+    std::uint16_t character = 0;
+    std::uint64_t utf16_size;
+
+    auto uint16_s = sizeof(std::uint16_t);
+    // save current offset
+    auto curr_offset = input_file.tellg();
+
+    // set the offset to the given offset
+    input_file.seekg(static_cast<std::streampos>(offset));
+
+    utf16_size = read_uleb128();
+
+    while (utf16_size-- > 0) {
+        input_file.read(reinterpret_cast<char*>(&character), uint16_s);
+        new_str += static_cast<wchar_t>(character);
+    }
+
+    // return again
+    input_file.seekg(curr_offset);
+    return new_str;
+}
+
 std::string ShurikenStream::read_dex_string(std::int64_t offset) {
     std::string new_str = "";
     std::int8_t character = -1;

--- a/shuriken/lib/disassembler/Dex/dex_instructions.cpp
+++ b/shuriken/lib/disassembler/Dex/dex_instructions.cpp
@@ -757,7 +757,8 @@ Instruction21c::Instruction21c(std::span<uint8_t> bytecode, std::size_t index, s
     switch (get_kind()) {
         case shuriken::dex::TYPES::STRING:
             source_id = parser->get_strings().get_string_by_id(iBBBB);
-            wstr = parser->get_strings().get_unicode_string_by_id(iBBBB);
+            if (parser->get_strings().is_unicode_available())
+                wstr = parser->get_strings().get_unicode_string_by_id(iBBBB);
             break;
         case shuriken::dex::TYPES::TYPE:
             source_id = parser->get_types().get_type_by_id(iBBBB);

--- a/shuriken/lib/disassembler/Dex/disassembled_method.cpp
+++ b/shuriken/lib/disassembler/Dex/disassembled_method.cpp
@@ -188,7 +188,7 @@ std::wstring_view DisassembledMethod::print_method_unicode(bool print_address) {
             if (print_address)
                 output << std::hex << std::setw(8) << std::setfill(L'0') << id;
             output << ' ';
-            /// now print the instruction
+            /// now print the instruction in unicode
             output << instr->print_winstruction();
             id += instr->get_instruction_length();
             output << '\n';

--- a/shuriken/lib/parser/Dex/dex_strings.cpp
+++ b/shuriken/lib/parser/Dex/dex_strings.cpp
@@ -23,7 +23,8 @@ namespace {
 
 void DexStrings::parse_strings(common::ShurikenStream &shuriken_stream,
                                std::uint32_t strings_offset,
-                               std::uint32_t n_of_strings) {
+                               std::uint32_t n_of_strings,
+                               bool read_unicode) {
     log(LEVEL::INFO, "Start parsing strings");
 
     auto current_offset = shuriken_stream.tellg();
@@ -40,6 +41,8 @@ void DexStrings::parse_strings(common::ShurikenStream &shuriken_stream,
             throw std::runtime_error("Error string offset out of bound");
 
         dex_strings.emplace_back(shuriken_stream.read_dex_string(str_offset));
+        if (read_unicode)
+            dex_wstrings.emplace_back(shuriken_stream.read_unicode_string(str_offset));
     }
 
     shuriken_stream.seekg(current_offset, std::ios_base::beg);
@@ -71,9 +74,17 @@ void DexStrings::dump_binary(std::ofstream &fos, std::int64_t offset) {
 }
 
 std::string_view DexStrings::get_string_by_id(std::uint32_t str_id) const {
-    if (str_id >= dex_strings.size())
+    if (str_id >= dex_strings.size()) 
         throw std::runtime_error("Error id of string out of bound");
     return dex_strings.at(str_id);
+}
+
+std::wstring_view DexStrings::get_unicode_string_by_id(std::uint32_t str_id) const {
+    if (dex_wstrings.empty())
+        throw std::runtime_error("Error, you must parse dex with read_unicode");
+    if (str_id >= dex_wstrings.size()) 
+        throw std::runtime_error("Error id of string out of bound");
+    return dex_wstrings.at(str_id);
 }
 
 size_t DexStrings::get_number_of_strings() const {

--- a/shuriken/lib/parser/Dex/dex_strings.cpp
+++ b/shuriken/lib/parser/Dex/dex_strings.cpp
@@ -29,6 +29,7 @@ void DexStrings::parse_strings(common::ShurikenStream &shuriken_stream,
 
     auto current_offset = shuriken_stream.tellg();
     std::uint32_t str_offset;// we will read offsets
+    this->unicode_available = read_unicode;
 
     // move pointer to the given offset
     shuriken_stream.seekg_safe(strings_offset, std::ios_base::beg);
@@ -85,6 +86,10 @@ std::wstring_view DexStrings::get_unicode_string_by_id(std::uint32_t str_id) con
     if (str_id >= dex_wstrings.size()) 
         throw std::runtime_error("Error id of string out of bound");
     return dex_wstrings.at(str_id);
+}
+
+bool DexStrings::is_unicode_available() const {
+    return unicode_available;
 }
 
 size_t DexStrings::get_number_of_strings() const {

--- a/shuriken/lib/parser/Dex/parser.cpp
+++ b/shuriken/lib/parser/Dex/parser.cpp
@@ -11,6 +11,10 @@
 
 using namespace shuriken::parser::dex;
 
+void Parser::set_read_unicode(bool read_unicode) {
+    this->read_unicode = read_unicode;
+}
+
 void Parser::parse_dex(common::ShurikenStream &stream) {
     std::uint8_t magic[4];
     log(LEVEL::INFO, "Start parsing dex file");
@@ -36,7 +40,8 @@ void Parser::parse_dex(common::ShurikenStream &stream) {
                             dex_header.map_off);
     strings_.parse_strings(stream,
                            dex_header.string_ids_off,
-                           dex_header.string_ids_size);
+                           dex_header.string_ids_size,
+                           read_unicode);
     types_.parse_types(stream,
                        strings_,
                        dex_header.type_ids_off,
@@ -134,26 +139,29 @@ const DexClasses &Parser::get_classes() const {
 
 namespace shuriken {
     namespace parser {
-        std::unique_ptr<dex::Parser> parse_dex(common::ShurikenStream &file) {
+        std::unique_ptr<dex::Parser> parse_dex(common::ShurikenStream &file, bool read_unicode) {
             auto p = std::make_unique<dex::Parser>();
+            p->set_read_unicode(read_unicode);
             p->parse_dex(file);
             return p;
         }
 
-        std::unique_ptr<dex::Parser> parse_dex(const std::string &file_path) {
+        std::unique_ptr<dex::Parser> parse_dex(const std::string &file_path, bool read_unicode) {
             std::ifstream ifs(file_path, std::ios::binary);
             common::ShurikenStream file(ifs);
 
             auto p = std::make_unique<dex::Parser>();
+            p->set_read_unicode(read_unicode);
             p->parse_dex(file);
             return p;
         }
 
-        dex::Parser *parse_dex(const char *file_path) {
+        dex::Parser *parse_dex(const char *file_path, bool read_unicode) {
             std::ifstream ifs(file_path, std::ios::binary);
             common::ShurikenStream file(ifs);
 
             auto *p = new Parser();
+            p->set_read_unicode(read_unicode);
             p->parse_dex(file);
             return p;
         }


### PR DESCRIPTION
Work for improving Shuriken to support unicode strings. Specially used for the disassembly of applications that can use unicode strings.