### PR TITLE
Extend Mach-O parser to include commands and sections

### DIFF
--- a/shuriken-dump/shuriken-dump.cpp
+++ b/shuriken-dump/shuriken-dump.cpp
@@ -485,7 +485,7 @@ void print_code(std::span<std::uint8_t> bytecode) {
     void print_macho_sections(const shuriken::parser::macho::MachoSections &sections) {
         const shuriken::parser::macho::MachoSections::sections_t&  macho_sections = sections.get_sections_const();
 
-        for (const std::shared_ptr<shuriken::parser::macho::MachoSections::section_t>& section: macho_sections) {
+        for (const std::unique_ptr<shuriken::parser::macho::MachoSections::section_t>& section: macho_sections) {
             fmt::println("Section:\n");
             fmt::print(" Type:                  {}\n", section->sectname);
             fmt::print(" Seg:                   {}\n", section->segname);

--- a/shuriken-dump/shuriken-dump.cpp
+++ b/shuriken-dump/shuriken-dump.cpp
@@ -454,51 +454,54 @@ void print_code(std::span<std::uint8_t> bytecode) {
     }
 
     void print_macho_loadcommands(const shuriken::parser::macho::MachoCommands &commands) {
-        const shuriken::parser::macho::MachoCommands::loadcommands_t& macho_loadcommands = commands.get_macho_loadcommands_const();
+        const shuriken::parser::macho::MachoCommands::loadcommands_s_t& macho_loadcommands = commands.get_macho_loadcommands_const();
 
-        for (const std::unique_ptr<shuriken::parser::macho::MachoCommands::loadcommand_t>& loadcommand : macho_loadcommands) {
+        for (const auto& loadcommand : macho_loadcommands) {
+            const auto& loadcommand_ref = loadcommand.get();  
             fmt::println("Load command:\n");
-            fmt::print(" Type:                  0x{:X}\n", loadcommand->cmd);
-            fmt::print(" Size:                  {} bytes\n", loadcommand->cmdsize);
+            fmt::print(" Type:                  0x{:X}\n", loadcommand_ref.cmd);
+            fmt::print(" Size:                  {} bytes\n", loadcommand_ref.cmdsize);
         }
     }
 
     void print_macho_segmentcommands(const shuriken::parser::macho::MachoCommands &commands) {
-        const shuriken::parser::macho::MachoCommands::segmentcommands_t& macho_segmentcommands = commands.get_macho_segmentcommands_const();
+        const shuriken::parser::macho::MachoCommands::segmentcommands_s_t& macho_segmentcommands = commands.get_macho_segmentcommands_const();
 
-        for (const std::unique_ptr<shuriken::parser::macho::MachoCommands::segmentcommand_t>& segmentcommand : macho_segmentcommands) {
+        for (const auto& segmentcommand : macho_segmentcommands) {
+            const auto& segmentcommand_ref = segmentcommand.get();  
             fmt::println("Segment command:\n");
-            fmt::print(" Type:                  0x{:X}\n", segmentcommand->cmd);
-            fmt::print(" Size:                  {} bytes\n", segmentcommand->cmdsize);
-            fmt::print(" Name:                  {}\n", segmentcommand->segname);
-            fmt::print(" VM address:            0x{:X}\n", segmentcommand->vmaddr);
-            fmt::print(" VM size:               0x{:X}\n", segmentcommand->vmsize);
-            fmt::print(" Offset in file:        0x{:X}\n", segmentcommand->fileoff);
-            fmt::print(" Size in file:          0x{:X}\n", segmentcommand->filesize);
-            fmt::print(" Max memory protection: 0x{:X}\n", segmentcommand->maxprot);
-            fmt::print(" Initial memory prot:   0x{:X}\n", segmentcommand->initprot);
-            fmt::print(" Number of Sections:    0x{:X}\n", segmentcommand->nsects);
-            fmt::print(" Flags:                 0x{:X}\n", segmentcommand->flags);
+            fmt::print(" Type:                  0x{:X}\n", segmentcommand_ref.cmd);
+            fmt::print(" Size:                  {} bytes\n", segmentcommand_ref.cmdsize);
+            fmt::print(" Name:                  {}\n", segmentcommand_ref.segname);
+            fmt::print(" VM address:            0x{:X}\n", segmentcommand_ref.vmaddr);
+            fmt::print(" VM size:               0x{:X}\n", segmentcommand_ref.vmsize);
+            fmt::print(" Offset in file:        0x{:X}\n", segmentcommand_ref.fileoff);
+            fmt::print(" Size in file:          0x{:X}\n", segmentcommand_ref.filesize);
+            fmt::print(" Max memory protection: 0x{:X}\n", segmentcommand_ref.maxprot);
+            fmt::print(" Initial memory prot:   0x{:X}\n", segmentcommand_ref.initprot);
+            fmt::print(" Number of Sections:    0x{:X}\n", segmentcommand_ref.nsects);
+            fmt::print(" Flags:                 0x{:X}\n", segmentcommand_ref.flags);
         }
     }
 
     void print_macho_sections(const shuriken::parser::macho::MachoSections &sections) {
-        const shuriken::parser::macho::MachoSections::sections_t&  macho_sections = sections.get_sections_const();
+        const shuriken::parser::macho::MachoSections::sections_s_t&  macho_sections = sections.get_sections_const();
 
-        for (const std::unique_ptr<shuriken::parser::macho::MachoSections::section_t>& section: macho_sections) {
+        for (const auto& section: macho_sections) {
+            const auto& section_ref = section.get();  
             fmt::println("Section:\n");
-            fmt::print(" Type:                  {}\n", section->sectname);
-            fmt::print(" Seg:                   {}\n", section->segname);
-            fmt::print(" Address:               0x{:X}\n", section->addr);
-            fmt::print(" Size:                  {} bytes\n", section->size);
-            fmt::print(" File offset:           0x{:X}\n", section->offset);
-            fmt::print(" Alignment:             {} bytes\n", (1 << section->align));
-            fmt::print(" Relocation offset:     0x{:X}\n", section->reloff);
-            fmt::print(" Number of relocations: {}\n", section->nreloc);
-            fmt::print(" Flags:                 0x{:X}\n", section->flags);
-            fmt::print(" Reserved1:             0x{:X}\n", section->reserved1);
-            fmt::print(" Reserved2:             0x{:X}\n", section->reserved2);
-            fmt::print(" Reserved3:             0x{:X}\n", section->reserved3);
+            fmt::print(" Type:                  {}\n", section_ref.sectname);
+            fmt::print(" Seg:                   {}\n", section_ref.segname);
+            fmt::print(" Address:               0x{:X}\n", section_ref.addr);
+            fmt::print(" Size:                  {} bytes\n", section_ref.size);
+            fmt::print(" File offset:           0x{:X}\n", section_ref.offset);
+            fmt::print(" Alignment:             {} bytes\n", (1 << section_ref.align));
+            fmt::print(" Relocation offset:     0x{:X}\n", section_ref.reloff);
+            fmt::print(" Number of relocations: {}\n", section_ref.nreloc);
+            fmt::print(" Flags:                 0x{:X}\n", section_ref.flags);
+            fmt::print(" Reserved1:             0x{:X}\n", section_ref.reserved1);
+            fmt::print(" Reserved2:             0x{:X}\n", section_ref.reserved2);
+            fmt::print(" Reserved3:             0x{:X}\n", section_ref.reserved3);
         }
     }
 #endif

--- a/shuriken/include/shuriken/parser/Macho/macho_commands.h
+++ b/shuriken/include/shuriken/parser/Macho/macho_commands.h
@@ -43,14 +43,19 @@ namespace shuriken::parser::macho {
         };
 
         using loadcommands_t = std::vector<std::unique_ptr<loadcommand_t>>;
+        using loadcommands_s_t = std::vector<std::reference_wrapper<loadcommand_t>>;
+
         using segmentcommands_t = std::vector<std::unique_ptr<segmentcommand_t>>;
+        using segmentcommands_s_t = std::vector<std::reference_wrapper<segmentcommand_t>>;
 
     private:
         /// @brief array with the load commands from the macho
         loadcommands_t loadcommands;
+        mutable loadcommands_s_t loadcommands_s;
 
         /// @brief array with the segment commands from the macho
         segmentcommands_t segmentcommands;
+        mutable segmentcommands_s_t segmentcommands_s;
 
     public:
         /// @brief Constructor for the load command, default one
@@ -69,12 +74,12 @@ namespace shuriken::parser::macho {
         /// @brief Obtain a reference of the macho load commands 
         /// if not value will be modified, use this function
         /// @return const reference to macho load commands
-        const loadcommands_t &get_macho_loadcommands_const() const;
+        const loadcommands_s_t &get_macho_loadcommands_const() const;
 
         /// @brief Obtain a reference of the macho segment commands
         /// if not value will be modified, use this function
         /// @return const reference to macho segment commands
-        const segmentcommands_t &get_macho_segmentcommands_const() const;
+        const segmentcommands_s_t &get_macho_segmentcommands_const() const;
     };
 }// namespace shuriken::parser::macho
 

--- a/shuriken/include/shuriken/parser/Macho/macho_commands.h
+++ b/shuriken/include/shuriken/parser/Macho/macho_commands.h
@@ -1,0 +1,81 @@
+//--------------------------------------------------------------------*- C++ -*-
+// Shuriken-Analyzer: library for bytecode analysis.
+// @author Farenain <kunai.static.analysis@gmail.com>
+//
+// @file header.h
+// @brief MachoCommand of a MACHO file represented by a structure
+
+#ifndef SHURIKENLIB_MACHO_COMMANDS_H
+#define SHURIKENLIB_MACHO_COMMANDS_H
+
+#include "shuriken/parser/Macho/macho_sections.h"
+#include "shuriken/common/shurikenstream.h"
+
+#include <vector>
+#include <memory>
+
+namespace shuriken::parser::macho {
+    class MachoCommands {
+    public:
+        /// @brief Structure with the definition of the MACHO load command
+        /// all these values are later used for parsing the load command
+        /// from MACHO
+        struct loadcommand_t {
+            uint32_t cmd;               //! command type
+            uint32_t cmdsize;           //! command size
+        };
+
+        /// @brief Structure with the definition of the MACHO segment load command
+        /// all these values are later used for parsing the segment load command
+        /// from MACHO
+        struct segmentcommand_t {
+            uint32_t cmd;               //! command type
+            uint32_t cmdsize;           //! command size
+            char segname[16];           //! segment type
+            uint64_t vmaddr;            //! virtual memory address 
+            uint64_t vmsize;            //! size of the segment in the virtual memory
+            uint64_t fileoff;           //! offset 
+            uint64_t filesize;          //! size of the segment's data
+            uint32_t maxprot;           //! maximum VM protection 
+            uint32_t initprot;          //! initial VM protection 
+            uint32_t nsects;            //! number of sections 
+            uint32_t flags;             //! flags 
+        };
+
+        using loadcommands_t = std::vector<std::unique_ptr<loadcommand_t>>;
+        using segmentcommands_t = std::vector<std::unique_ptr<segmentcommand_t>>;
+
+    private:
+        /// @brief array with the load commands from the macho
+        loadcommands_t loadcommands;
+
+        /// @brief array with the segment commands from the macho
+        segmentcommands_t segmentcommands;
+
+    public:
+        /// @brief Constructor for the load command, default one
+        MachoCommands() = default;
+
+        /// @brief Destructor for the load command, default one
+        ~MachoCommands() = default;
+
+        /// @brief Parse the load command from a ShurikenStream file
+        /// @param stream ShurikenStream where to read the header.
+        /// @param number_of_commands number of commands of the Mach-O file
+        void parse_commands(common::ShurikenStream &stream, 
+                            uint32_t number_of_commands, 
+                            MachoSections &sections);
+
+        /// @brief Obtain a reference of the macho load commands 
+        /// if not value will be modified, use this function
+        /// @return const reference to macho load commands
+        const loadcommands_t &get_macho_loadcommands_const() const;
+
+        /// @brief Obtain a reference of the macho segment commands
+        /// if not value will be modified, use this function
+        /// @return const reference to macho segment commands
+        const segmentcommands_t &get_macho_segmentcommands_const() const;
+    };
+}// namespace shuriken::parser::macho
+
+#endif//SHURIKENLIB_MACHO_COMMANDS_H

--- a/shuriken/include/shuriken/parser/Macho/macho_sections.h
+++ b/shuriken/include/shuriken/parser/Macho/macho_sections.h
@@ -1,0 +1,76 @@
+//--------------------------------------------------------------------*- C++ -*-
+// Shuriken-Analyzer: library for bytecode analysis.
+// @author Farenain <kunai.static.analysis@gmail.com>
+//
+// @file section.h
+// @brief MachoSections of a MACHO file represented by a structure
+
+#ifndef SHURIKENLIB_MACHO_SECTIONS_H
+#define SHURIKENLIB_MACHO_SECTIONS_H
+
+#include "shuriken/common/shurikenstream.h"
+
+#include <cstring>
+#include <iostream>
+#include <vector>
+#include <memory>
+#include <map>
+
+namespace shuriken::parser::macho {
+    class MachoSections {
+    public:
+        /// @brief Structure with the definition of the MACHO section
+        /// all these values are later used for parsing the section
+        /// from MACHO
+        struct section_t {
+            char sectname[16];          //! section type
+            char segname[16];           //! segment type
+            uint64_t addr;              //! starting position of the section
+            uint64_t size;              //! size of the section
+            uint32_t offset;            //! data's offset of the section
+            uint32_t align;             //! alignment in memory, power of 2
+            uint32_t reloff;            //! offset to the relocation entries for this section
+            uint32_t nreloc;            //! number of relocation entries for this section
+            uint32_t flags;             //! flags
+            uint32_t reserved1;         //! reserved space for additional info
+            uint32_t reserved2;         //! reserved space for additional info
+            uint32_t reserved3;         //! reserved space for additional info
+        };
+
+        using sections_t = std::vector<std::shared_ptr<section_t>>;
+        using segmentsections_t = std::map<uint32_t, sections_t>;
+
+    private:
+        /// @brief array with the segment sections
+        sections_t sections_;
+
+        /// @brief map with each segment's sections
+        segmentsections_t segmentsections_;
+    
+    public:
+        /// @brief Constructor for the sections, default one
+        MachoSections() = default;
+
+        /// @brief Destructor for the sections, default one
+        ~MachoSections() = default;
+
+        /// @brief Parse the sections from a ShurikenStream file
+        /// @param stream ShurikenStream where to read the header
+        /// @param number_of_sections number of sections of the segment
+        void parse_sections(common::ShurikenStream &stream, 
+                            uint32_t number_of_sections, 
+                            uint32_t file_offset);
+
+        /// @brief Obtain a reference of the segment sections 
+        /// if not value will be modified, use this function
+        /// @return const reference to segment sections
+        const sections_t &get_sections_const() const;
+
+        /// @brief Obtain a reference of a macho segment's sections
+        /// if not value will be modified, use this function
+        /// @return const reference to macho segment sections
+        const segmentsections_t &get_segmentsections_const() const;
+    };
+}// namespace shuriken::parser::macho
+
+#endif//SHURIKENLIB_MACHO_SECTIONS_H

--- a/shuriken/include/shuriken/parser/Macho/macho_sections.h
+++ b/shuriken/include/shuriken/parser/Macho/macho_sections.h
@@ -37,8 +37,8 @@ namespace shuriken::parser::macho {
             uint32_t reserved3;         //! reserved space for additional info
         };
 
-        using sections_t = std::vector<std::shared_ptr<section_t>>;
-        using segmentsections_t = std::map<uint32_t, sections_t>;
+        using sections_t = std::vector<std::unique_ptr<section_t>>;
+        using segmentsections_t = std::map<uint32_t, std::vector<std::reference_wrapper<section_t>>>;
 
     private:
         /// @brief array with the segment sections

--- a/shuriken/include/shuriken/parser/Macho/macho_sections.h
+++ b/shuriken/include/shuriken/parser/Macho/macho_sections.h
@@ -38,11 +38,13 @@ namespace shuriken::parser::macho {
         };
 
         using sections_t = std::vector<std::unique_ptr<section_t>>;
+        using sections_s_t = std::vector<std::reference_wrapper<section_t>>;
         using segmentsections_t = std::map<uint32_t, std::vector<std::reference_wrapper<section_t>>>;
 
     private:
         /// @brief array with the segment sections
         sections_t sections_;
+        mutable sections_s_t sections_s_;
 
         /// @brief map with each segment's sections
         segmentsections_t segmentsections_;
@@ -64,7 +66,7 @@ namespace shuriken::parser::macho {
         /// @brief Obtain a reference of the segment sections 
         /// if not value will be modified, use this function
         /// @return const reference to segment sections
-        const sections_t &get_sections_const() const;
+        const sections_s_t &get_sections_const() const;
 
         /// @brief Obtain a reference of a macho segment's sections
         /// if not value will be modified, use this function

--- a/shuriken/include/shuriken/parser/Macho/parser.h
+++ b/shuriken/include/shuriken/parser/Macho/parser.h
@@ -1,0 +1,52 @@
+//--------------------------------------------------------------------*- C++ -*-
+// Shuriken-Analyzer: library for bytecode analysis.
+// @author Farenain <kunai.static.analysis@gmail.com>
+//
+// @file parser.h
+// @brief Parser for the MACHO file, here we contain objects for all the other
+// fields
+
+#ifndef SHURIKENLIB_MACHO_PARSER_H
+#define SHURIKENLIB_MACHO_PARSER_H
+
+#include "shuriken/common/shurikenstream.h"
+#include "shuriken/parser/Macho/macho_header.h"
+#include "shuriken/parser/Macho/macho_commands.h"
+#include "shuriken/parser/Macho/macho_sections.h"
+
+#include <vector>
+#include <memory>
+
+namespace shuriken::parser::macho {
+
+    class Parser {
+    private:
+        /// @brief MachoHeader of the MACHO file
+        MachoHeader header_;
+
+        /// @brief MachoCommands of the MACHO file
+        MachoCommands commands_;
+
+        /// @brief MachoSections of the MACHO file
+        MachoSections sections_;
+
+    public:
+        /// @brief Default constructor of the java
+        Parser() = default;
+        /// @brief Default destructor of the java
+        ~Parser() = default;
+
+        /// @brief parse the macho file from the stream
+        /// @param stream stream from where to retrieve the macho data
+        void parse_macho(common::ShurikenStream &stream);
+
+        const MachoHeader &get_header() const;
+
+        const MachoCommands &get_commands() const;
+
+        const MachoSections &get_sections() const;
+    };
+
+}// namespace shuriken::parser::macho
+
+#endif//SHURIKENLIB_MACHO_PARSER_H

--- a/shuriken/include/shuriken/parser/shuriken_parsers.h
+++ b/shuriken/include/shuriken/parser/shuriken_parsers.h
@@ -13,6 +13,7 @@
 #include "shuriken/common/shurikenstream.h"
 #include "shuriken/parser/Apk/apk.h"
 #include "shuriken/parser/Dex/parser.h"
+#include "shuriken/parser/Macho/parser.h"
 #include <memory>
 
 namespace shuriken::parser {
@@ -22,6 +23,10 @@ namespace shuriken::parser {
 
     std::unique_ptr<apk::Apk> parse_apk(const std::string &file_path, bool created_xrefs);
     std::unique_ptr<apk::Apk> parse_apk(const char *file_path, bool created_xrefs);
+
+    std::unique_ptr<macho::Parser> parse_macho(common::ShurikenStream &file);
+    std::unique_ptr<macho::Parser> parse_macho(const std::string &file_path);
+    macho::Parser *parse_macho(const char *file_path);
 }// namespace shuriken::parser
 
 #endif//SHURIKENLIB_SHURIKEN_PARSERS_H

--- a/shuriken/lib/parser/Macho/CMakeLists.txt
+++ b/shuriken/lib/parser/Macho/CMakeLists.txt
@@ -1,3 +1,6 @@
 target_sources(macho-obj PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/parser.cpp
         ${CMAKE_CURRENT_LIST_DIR}/macho_header.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/macho_commands.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/macho_sections.cpp
 )

--- a/shuriken/lib/parser/Macho/macho_commands.cpp
+++ b/shuriken/lib/parser/Macho/macho_commands.cpp
@@ -1,0 +1,57 @@
+//--------------------------------------------------------------------*- C++ -*-
+// Shuriken-Analyzer: library for bytecode analysis.
+// @author Farenain <kunai.static.analysis@gmail.com>
+//
+// @file macho_commands.cpp
+
+#include "shuriken/parser/Macho/macho_commands.h"
+#include "shuriken/common/logger.h"
+
+#define LC_SEGMENT 0x19        
+
+using namespace shuriken::parser::macho;
+
+void MachoCommands::parse_commands(common::ShurikenStream &stream, 
+                                uint32_t number_of_commands, 
+                                MachoSections &sections) {
+
+    log(LEVEL::INFO, "Start parsing commands");
+    
+    // parse load commands
+    for (uint32_t i = 0; i < number_of_commands; ++i) {
+        loadcommand_t loadcommand;
+        stream.read_data<loadcommand_t>(loadcommand, sizeof(loadcommand_t));
+        loadcommands.emplace_back(std::make_unique<loadcommand_t>(loadcommand));
+
+        // parse segment commands
+        if (loadcommand.cmd == LC_SEGMENT) {
+            stream.seekg(-sizeof(loadcommand), std::ios::cur);
+        
+            segmentcommand_t segmentcommand;
+            stream.read_data<segmentcommand_t>(segmentcommand, sizeof(segmentcommand));
+            segmentcommands.emplace_back(std::make_unique<segmentcommand_t>(segmentcommand));
+            
+            // parse sections
+            if (std::string(segmentcommand.segname) == "__DATA" || 
+                std::string(segmentcommand.segname) == "__DATA_CONST") { 
+                    sections.parse_sections(stream, 
+                                            segmentcommand.nsects, 
+                                            segmentcommand.fileoff);
+            } else {
+                stream.seekg(segmentcommand.cmdsize - sizeof(segmentcommand), std::ios::cur);
+            }
+        } else {
+            stream.seekg(loadcommand.cmdsize - sizeof(loadcommand), std::ios::cur);
+        }
+    }
+
+    log(LEVEL::INFO, "Finished parsing commands");
+}
+
+const MachoCommands::loadcommands_t &MachoCommands::get_macho_loadcommands_const() const {
+    return loadcommands;
+}
+
+const MachoCommands::segmentcommands_t &MachoCommands::get_macho_segmentcommands_const() const {
+    return segmentcommands;
+}

--- a/shuriken/lib/parser/Macho/macho_commands.cpp
+++ b/shuriken/lib/parser/Macho/macho_commands.cpp
@@ -48,10 +48,20 @@ void MachoCommands::parse_commands(common::ShurikenStream &stream,
     log(LEVEL::INFO, "Finished parsing commands");
 }
 
-const MachoCommands::loadcommands_t &MachoCommands::get_macho_loadcommands_const() const {
-    return loadcommands;
+const MachoCommands::loadcommands_s_t &MachoCommands::get_macho_loadcommands_const() const {
+    if (loadcommands_s.empty() || loadcommands_s.size() != loadcommands.size()) {
+        loadcommands_s.clear();
+        for (const auto &entry: loadcommands)
+            loadcommands_s.push_back(std::ref(*entry));
+    }
+    return loadcommands_s;
 }
 
-const MachoCommands::segmentcommands_t &MachoCommands::get_macho_segmentcommands_const() const {
-    return segmentcommands;
+const MachoCommands::segmentcommands_s_t &MachoCommands::get_macho_segmentcommands_const() const {
+    if (segmentcommands_s.empty() || segmentcommands_s.size() != segmentcommands.size()) {
+        segmentcommands_s.clear();
+        for (const auto &entry: segmentcommands)
+            segmentcommands_s.push_back(std::ref(*entry));
+    }
+    return segmentcommands_s;
 }

--- a/shuriken/lib/parser/Macho/macho_sections.cpp
+++ b/shuriken/lib/parser/Macho/macho_sections.cpp
@@ -30,8 +30,13 @@ void MachoSections::parse_sections(common::ShurikenStream &stream,
     log(LEVEL::INFO, "Finished parsing sections");
 }
 
-const MachoSections::sections_t &MachoSections::get_sections_const() const {
-    return sections_;
+const MachoSections::sections_s_t &MachoSections::get_sections_const() const {
+    if (sections_s_.empty() || sections_s_.size() != sections_.size()) {
+        sections_s_.clear();
+        for (const auto &entry: sections_)
+            sections_s_.push_back(std::ref(*entry));
+    }
+    return sections_s_;
 }
 
 const MachoSections::segmentsections_t &MachoSections::get_segmentsections_const() const {

--- a/shuriken/lib/parser/Macho/macho_sections.cpp
+++ b/shuriken/lib/parser/Macho/macho_sections.cpp
@@ -1,0 +1,39 @@
+//--------------------------------------------------------------------*- C++ -*-
+// Shuriken-Analyzer: library for bytecode analysis.
+// @author Farenain <kunai.static.analysis@gmail.com>
+//
+// @file macho_sections.cpp
+
+#include "shuriken/parser/Macho/macho_sections.h"
+#include "shuriken/common/logger.h"       
+
+using namespace shuriken::parser::macho;
+
+void MachoSections::parse_sections(common::ShurikenStream &stream, 
+                                uint32_t number_of_sections, 
+                                uint32_t file_offset) {
+
+    log(LEVEL::INFO, "Start parsing sections");
+    
+    sections_t segmentsections;  
+
+    // parse sections
+    for (uint32_t i = 0; i < number_of_sections; ++i) {
+        section_t section;
+        stream.read_data<section_t>(section, sizeof(section_t));
+        sections_.emplace_back(std::make_shared<section_t>(section));
+        segmentsections.emplace_back(std::make_shared<section_t>(section));
+    }
+
+    segmentsections_[file_offset] = segmentsections;
+
+    log(LEVEL::INFO, "Finished parsing sections");
+}
+
+const MachoSections::sections_t &MachoSections::get_sections_const() const {
+    return sections_;
+}
+
+const MachoSections::segmentsections_t &MachoSections::get_segmentsections_const() const {
+    return segmentsections_;
+}

--- a/shuriken/lib/parser/Macho/macho_sections.cpp
+++ b/shuriken/lib/parser/Macho/macho_sections.cpp
@@ -15,14 +15,14 @@ void MachoSections::parse_sections(common::ShurikenStream &stream,
 
     log(LEVEL::INFO, "Start parsing sections");
     
-    sections_t segmentsections;  
+    std::vector<std::reference_wrapper<section_t>> segmentsections;
 
     // parse sections
     for (uint32_t i = 0; i < number_of_sections; ++i) {
         section_t section;
         stream.read_data<section_t>(section, sizeof(section_t));
-        sections_.emplace_back(std::make_shared<section_t>(section));
-        segmentsections.emplace_back(std::make_shared<section_t>(section));
+        sections_.emplace_back(std::make_unique<section_t>(section));
+        segmentsections.emplace_back(*sections_.back());
     }
 
     segmentsections_[file_offset] = segmentsections;

--- a/shuriken/lib/parser/Macho/parser.cpp
+++ b/shuriken/lib/parser/Macho/parser.cpp
@@ -1,0 +1,70 @@
+//--------------------------------------------------------------------*- C++ -*-
+// Shuriken-Analyzer: library for bytecode analysis.
+// @author Farenain <kunai.static.analysis@gmail.com>
+//
+// @file parser.cpp
+
+#include "shuriken/parser/Macho/parser.h"
+
+#include "shuriken/common/logger.h"
+
+using namespace shuriken::parser::macho;
+
+void Parser::parse_macho(common::ShurikenStream &stream) {
+    log(LEVEL::INFO, "Start parsing macho file");
+
+    if (stream.get_file_size() < sizeof(MachoHeader::machoheader_t))
+        throw std::runtime_error("Error file provided to parser has an incorrect size");
+
+    // parsing of header
+    header_.parse_header(stream);
+
+    const auto &macho_header = header_.get_macho_header_const();
+
+    // parsing of the commands
+    commands_.parse_commands(stream, 
+                            macho_header.ncmds, 
+                            sections_);
+
+    log(LEVEL::INFO, "Finished parsing macho file");
+}
+
+const MachoHeader &Parser::get_header() const {
+    return header_;
+}
+
+const MachoCommands &Parser::get_commands() const {
+    return commands_;
+}
+
+const MachoSections &Parser::get_sections() const {
+    return sections_;
+}
+
+namespace shuriken {
+    namespace parser {
+        std::unique_ptr<macho::Parser> parse_macho(common::ShurikenStream &file) {
+            auto p = std::make_unique<macho::Parser>();
+            p->parse_macho(file);
+            return p;
+        }
+
+        std::unique_ptr<macho::Parser> parse_macho(const std::string &file_path) {
+            std::ifstream ifs(file_path, std::ios::binary);
+            common::ShurikenStream file(ifs);
+
+            auto p = std::make_unique<macho::Parser>();
+            p->parse_macho(file);
+            return p;
+        }
+
+        macho::Parser *parse_macho(const char *file_path) {
+            std::ifstream ifs(file_path, std::ios::binary);
+            common::ShurikenStream file(ifs);
+
+            auto *p = new Parser();
+            p->parse_macho(file);
+            return p;
+        }
+    }// namespace parser
+}// namespace shuriken

--- a/shuriken/tests/macho/parser/headers-test-macho.cpp
+++ b/shuriken/tests/macho/parser/headers-test-macho.cpp
@@ -136,7 +136,7 @@ void check_header(const shuriken::parser::macho::MachoHeader &header) {
 
 void check_loadcommand(const shuriken::parser::macho::MachoCommands &commands) {
     [[maybe_unused]] auto &macho_loadcommands = commands.get_macho_loadcommands_const();
-    [[maybe_unused]] auto &macho_loadcommand = *macho_loadcommands.back();
+    [[maybe_unused]] auto &macho_loadcommand = macho_loadcommands.back().get();
 
     assert(loadcommand.cmd == macho_loadcommand.cmd && "Error: load command cmd incorrect");
     assert(loadcommand.cmdsize == macho_loadcommand.cmdsize && "Error: load command cmdsize incorrect");
@@ -144,7 +144,7 @@ void check_loadcommand(const shuriken::parser::macho::MachoCommands &commands) {
 
 void check_segmentcommand(const shuriken::parser::macho::MachoCommands &commands) {
     [[maybe_unused]] auto &macho_segmentcommands = commands.get_macho_segmentcommands_const();
-    [[maybe_unused]] auto &macho_segmentcommand = *macho_segmentcommands.back();
+    [[maybe_unused]] auto &macho_segmentcommand = macho_segmentcommands.back().get();
 
     assert(segmentcommand.cmd == macho_segmentcommand.cmd && "Error: segment command cmd incorrect");
     assert(segmentcommand.cmdsize == macho_segmentcommand.cmdsize && "Error: segment command cmdsize incorrect");
@@ -161,7 +161,7 @@ void check_segmentcommand(const shuriken::parser::macho::MachoCommands &commands
 
 void check_section(const shuriken::parser::macho::MachoSections &sections) {
     [[maybe_unused]] auto &macho_sections = sections.get_sections_const();
-    [[maybe_unused]] auto &macho_section = *macho_sections.back();
+    [[maybe_unused]] auto &macho_section = macho_sections.back().get();
 
     assert(std::strcmp(section.sectname, macho_section.sectname) == 0 && "Error: section sectname incorrect");
     assert(std::strcmp(section.segname, macho_section.segname) == 0 && "Error: section segname incorrect");

--- a/shuriken/tests/macho/parser/headers-test-macho.cpp
+++ b/shuriken/tests/macho/parser/headers-test-macho.cpp
@@ -1,18 +1,54 @@
 //--------------------------------------------------------------------*- C++ -*-
 // Shuriken-Analyzer: library for bytecode analysis.
-// @author Farenain <kunai.static.analysis@gmail.com>
+// @author Farenain
 //
 // @file headers-test-macho.cpp
 // @brief Test the values from the parser and check these
 // values are correct
 
 #include "macho-files-folder.inc"
-#include "shuriken/common/shurikenstream.h"
-#include "shuriken/parser/Macho/macho_header.h"
+#include "shuriken/parser/shuriken_parsers.h"
 
 #include <iostream>
 #include <cassert>
 
+#include <cstdint>
+#include <cstring>
+
+// Useful structures for tests
+struct loadcommand_t {
+    uint32_t cmd;      
+    uint32_t cmdsize;  
+};
+
+struct segmentcommand_t {
+    uint32_t cmd;               
+    uint32_t cmdsize;           
+    char segname[16];           
+    uint64_t vmaddr;             
+    uint64_t vmsize;             
+    uint64_t fileoff;           
+    uint64_t filesize;          
+    uint32_t maxprot;           
+    uint32_t initprot;           
+    uint32_t nsects;             
+    uint32_t flags;             
+};
+
+struct section_t {
+    char sectname[16];          
+    char segname[16];           
+    uint64_t addr;              
+    uint64_t size;              
+    uint32_t offset;            
+    uint32_t align;             
+    uint32_t reloff;            
+    uint32_t nreloc;            
+    uint32_t flags;             
+    uint32_t reserved1;         
+    uint32_t reserved2;         
+    uint32_t reserved3;         
+};
 
 // header data
 std::uint32_t magic = 0xfeedfacf;        
@@ -24,32 +60,119 @@ std::uint32_t sizeofcmds = 8856;
 std::uint32_t flags = 0x218085;        
 std::uint32_t reserved = 0x0;     
 
+// load command data
+struct loadcommand_t loadcommand = {
+    .cmd = 0x1d,
+    .cmdsize = 16
+};
 
-void check_header(const shuriken::parser::macho::MachoHeader::machoheader_t &header);
+// segment command data
+struct segmentcommand_t segmentcommand = {
+    .cmd = 0x19,
+    .cmdsize = 72,
+    .segname = "__LINKEDIT",
+    .vmaddr = 0x10043c000,
+    .vmsize = 0x60000,
+    .fileoff = 0x438000,
+    .filesize = 0x5da50,
+    .maxprot = 0x1,
+    .initprot = 0x1,
+    .nsects = 0x0,
+    .flags = 0x0
+};
+
+// section data
+struct section_t section = {
+    .sectname = "__common",
+    .segname = "__DATA", 
+    .addr = 0x10043a188,
+    .size = 569,
+    .offset = 0x0,
+    .align = 8,
+    .reloff = 0x0,
+    .nreloc = 0,
+    .flags = 0x1,
+    .reserved1 = 0x0,
+    .reserved2 = 0x0,
+    .reserved3 = 0x0
+};
+
+void check_header(const shuriken::parser::macho::MachoHeader &header);
+void check_loadcommand(const shuriken::parser::macho::MachoCommands &commands);
+void check_segmentcommand(const shuriken::parser::macho::MachoCommands &commands);
+void check_section(const shuriken::parser::macho::MachoSections &sections);
 
 int main() {
-    std::string test_path = MACHO_FILES_FOLDER
+    std::string test_file = MACHO_FILES_FOLDER
             "MachoHeaderParserTest";
-    std::ifstream test_file(test_path);
-    shuriken::common::ShurikenStream test_stream(test_file);
 
-    shuriken::parser::macho::MachoHeader macho_header;
-    macho_header.parse_header(test_stream);
-    auto &header = macho_header.get_macho_header_const();
+    std::unique_ptr<shuriken::parser::macho::Parser> macho_parser =
+            shuriken::parser::parse_macho(test_file);
+
+    auto &header = macho_parser->get_header();
+    auto &commands = macho_parser->get_commands();
+    auto &sections = macho_parser->get_sections();
 
     check_header(header);
+    check_loadcommand(commands);
+    check_segmentcommand(commands);
+    check_section(sections);
 
     return 0;
 }
 
+void check_header(const shuriken::parser::macho::MachoHeader &header) {
+    [[maybe_unused]] auto &macho_header = header.get_macho_header_const();
 
-void check_header(const shuriken::parser::macho::MachoHeader::machoheader_t &header) {
-    assert(magic == header.magic && "Error magic incorrect");
-    assert(cputype == header.cputype && "Error cputype incorrect");
-    assert(cpusubtype == header.cpusubtype && "Error cpusubtype incorrect");
-    assert(filetype == header.filetype && "Error filetype incorrect");
-    assert(ncmds == header.ncmds && "Error ncmds incorrect");
-    assert(sizeofcmds == header.sizeofcmds && "Error sizeofcmds incorrect");
-    assert(flags == header.flags && "Error flags incorrect");
-    assert(reserved == header.reserved && "Error reserved incorrect");
+    assert(magic == macho_header.magic && "Error magic incorrect");
+    assert(cputype == macho_header.cputype && "Error cputype incorrect");
+    assert(cpusubtype == macho_header.cpusubtype && "Error cpusubtype incorrect");
+    assert(filetype == macho_header.filetype && "Error filetype incorrect");
+    assert(ncmds == macho_header.ncmds && "Error ncmds incorrect");
+    assert(sizeofcmds == macho_header.sizeofcmds && "Error sizeofcmds incorrect");
+    assert(flags == macho_header.flags && "Error flags incorrect");
+    assert(reserved == macho_header.reserved && "Error reserved incorrect");
+}
+
+void check_loadcommand(const shuriken::parser::macho::MachoCommands &commands) {
+    [[maybe_unused]] auto &macho_loadcommands = commands.get_macho_loadcommands_const();
+    [[maybe_unused]] auto &macho_loadcommand = *macho_loadcommands.back();
+
+    assert(loadcommand.cmd == macho_loadcommand.cmd && "Error: load command cmd incorrect");
+    assert(loadcommand.cmdsize == macho_loadcommand.cmdsize && "Error: load command cmdsize incorrect");
+}
+
+void check_segmentcommand(const shuriken::parser::macho::MachoCommands &commands) {
+    [[maybe_unused]] auto &macho_segmentcommands = commands.get_macho_segmentcommands_const();
+    [[maybe_unused]] auto &macho_segmentcommand = *macho_segmentcommands.back();
+
+    assert(segmentcommand.cmd == macho_segmentcommand.cmd && "Error: segment command cmd incorrect");
+    assert(segmentcommand.cmdsize == macho_segmentcommand.cmdsize && "Error: segment command cmdsize incorrect");
+    assert(std::strcmp(segmentcommand.segname, macho_segmentcommand.segname) == 0 && "Error: segment command segname incorrect");
+    assert(segmentcommand.vmaddr == macho_segmentcommand.vmaddr && "Error: segment command vmaddr incorrect");
+    assert(segmentcommand.vmsize == macho_segmentcommand.vmsize && "Error: segment command vmsize incorrect");
+    assert(segmentcommand.fileoff == macho_segmentcommand.fileoff && "Error: segment command fileoff incorrect");
+    assert(segmentcommand.filesize == macho_segmentcommand.filesize && "Error: segment command filesize incorrect");
+    assert(segmentcommand.maxprot == macho_segmentcommand.maxprot && "Error: segment command maxprot incorrect");
+    assert(segmentcommand.initprot == macho_segmentcommand.initprot && "Error: segment command initprot incorrect");
+    assert(segmentcommand.nsects == macho_segmentcommand.nsects && "Error: segment command nsects incorrect");
+    assert(segmentcommand.flags == macho_segmentcommand.flags && "Error: segment command flags incorrect");
+}
+
+void check_section(const shuriken::parser::macho::MachoSections &sections) {
+    [[maybe_unused]] auto &macho_sections = sections.get_sections_const();
+    [[maybe_unused]] auto &macho_section = *macho_sections.back();
+
+    assert(std::strcmp(section.sectname, macho_section.sectname) == 0 && "Error: section sectname incorrect");
+    assert(std::strcmp(section.segname, macho_section.segname) == 0 && "Error: section segname incorrect");
+    assert(section.addr == macho_section.addr && "Error: section addr incorrect");
+    assert(section.size == macho_section.size && "Error: section size incorrect");
+    assert(section.offset == macho_section.offset && "Error: section offset incorrect");
+    assert(section.align == macho_section.align && "Error: section align incorrect");
+    assert(section.reloff == macho_section.reloff && "Error: section reloff incorrect");
+    assert(section.nreloc == macho_section.nreloc && "Error: section nreloc incorrect");
+    assert(section.flags == macho_section.flags && "Error: section flags incorrect");
+    assert(section.reserved1 == macho_section.reserved1 && "Error: section reserved1 incorrect");
+    assert(section.reserved2 == macho_section.reserved2 && "Error: section reserved2 incorrect");
+    assert(section.reserved3 == macho_section.reserved3 && "Error: section reserved3 incorrect");
 }


### PR DESCRIPTION
### Extend Mach-O parser to include commands and sections

- Implement parsing of load and segment commands (`macho_commands.*`) and sections (`macho_sections.*`)
- Wrap everything inside a parser (`Macho/parser.*`)
- Include tests (`headers-test-macho.cpp`) and dump (`shuriken-dump.cpp`)

Now we can almost parse a whole Mach-O file, with just the code left.

![image](https://github.com/user-attachments/assets/9b4b128d-79ea-4de5-81dd-57baf282c12c)
