### PR TITLE
Fix DEX header in C API

### DIFF
--- a/shuriken/include/shuriken/api/C/shuriken_core.h
+++ b/shuriken/include/shuriken/api/C/shuriken_core.h
@@ -160,6 +160,11 @@ SHURIKENCOREAPI int get_number_of_dex_files(hApkContext context);
 /// @return a string with the path of the dex file in the apk
 SHURIKENCOREAPI const char *get_dex_file_by_index(hApkContext context, unsigned int idx);
 
+/// @brief get the parsed header of one of the DEX file
+/// @param DEX file file to retrieve the number of classes
+/// @return parsed DEX header
+SHURIKENCOREAPI dexheader_t *get_header_for_dex_file(hApkContext context, const char* dex_file);
+
 /// @brief Every dex file contains a number of classes, retrieve it by
 /// the name of the dex file
 /// @param dex_file file to retrieve the number of classes

--- a/shuriken/include/shuriken/api/C/shuriken_core.h
+++ b/shuriken/include/shuriken/api/C/shuriken_core.h
@@ -50,6 +50,7 @@ SHURIKENCOREAPI void destroy_dex(hDexContext context);
 
 /// @brief get the parsed header of the DEX file
 /// @param context from the DEX file
+/// @return parsed DEX header
 SHURIKENCOREAPI dexheader_t *get_header(hDexContext context);
 
 /// @brief Get the number of strings from the DEX file

--- a/shuriken/include/shuriken/api/C/shuriken_core_data.h
+++ b/shuriken/include/shuriken/api/C/shuriken_core_data.h
@@ -90,51 +90,51 @@ enum access_flags_e {
 
 /// @brief Structure that represents the header of a DEX file
 typedef struct dexheader_t_ {
-    //! magic bytes from dex, different values are possible
+    /// @brief magic bytes from dex, different values are possible
     uint8_t magic[8];
-    //! checksum to see if file is correct
+    /// @brief checksum to see if file is correct
     uint32_t checksum;
-    //! signature of dex
+    /// @brief signature of dex
     uint8_t signature[20];
-    //! current file size
+    /// @brief current file size
     uint32_t file_size;
-    //! size of this header
+    /// @brief size of this header
     uint32_t header_size;
-    //! type of endianess of the file
+    /// @brief type of endianess of the file
     uint32_t endian_tag;
-    //! size of the link section, or 0 if this file isn't statically linked
+    /// @brief size of the link section, or 0 if this file isn't statically linked
     uint32_t link_size;
-    //! offset from the start of the file to the link section
+    /// @brief offset from the start of the file to the link section
     uint32_t link_off;
-    //! offset from the start of the file to the map item
+    /// @brief offset from the start of the file to the map item
     uint32_t map_off;
-    //! number of DexStrings
+    /// @brief number of DexStrings
     uint32_t string_ids_size;
-    //! offset of the DexStrings
+    /// @brief offset of the DexStrings
     uint32_t string_ids_off;
-    //! number of DexTypes
+    /// @brief number of DexTypes
     uint32_t type_ids_size;
-    //! offset of the DexTypes
+    /// @brief offset of the DexTypes
     uint32_t type_ids_off;
-    //! number of prototypes
+    /// @brief number of prototypes
     uint32_t proto_ids_size;
-    //! offset of the prototypes
+    /// @brief offset of the prototypes
     uint32_t proto_ids_off;
-    //! number of fields
+    /// @brief number of fields
     uint32_t field_ids_size;
-    //! offset of the fields
+    /// @brief offset of the fields
     uint32_t field_ids_off;
-    //! number of methods
+    /// @brief number of methods
     uint32_t method_ids_size;
-    //! offset of the methods
+    /// @brief offset of the methods
     uint32_t method_ids_off;
-    //! number of class definitions
+    /// @brief number of class definitions
     uint32_t class_defs_size;
-    //! offset of the class definitions
+    /// @brief offset of the class definitions
     uint32_t class_defs_off;
-    //! data area, containing all the support data for the tables listed above
+    /// @brief data area, containing all the support data for the tables listed above
     uint32_t data_size;
-    //!
+    /// @brief offset of the data area
     uint32_t data_off;
 } dexheader_t;
 


### PR DESCRIPTION
In #156 I added support for the DEX header from the C API. However I forgot to also add the function to get the DEX header from an APK. This pull request fixes that and has some other minor changes, mostly syntax in the comments of the `dexheader_t` struct.